### PR TITLE
fix: give weapon holstering weapons

### DIFF
--- a/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/cl_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/cl_init.lua
@@ -22,6 +22,7 @@ end
 FAdmin.StartHooks["GiveWeapons"] = function()
     FAdmin.Access.AddPrivilege("giveweapon", 2)
     FAdmin.Commands.AddCommand("giveweapon", nil, "<Player>", "<weapon>")
+    FAdmin.Commands.AddCommand("giveholsterableweapon", nil, "<Player>", "<weapon>")
 
     FAdmin.ScoreBoard.Player:AddActionButton("Give weapon(s)", "fadmin/icons/weapon", Color(255, 130, 0, 255),
 

--- a/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/cl_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/cl_init.lua
@@ -22,7 +22,6 @@ end
 FAdmin.StartHooks["GiveWeapons"] = function()
     FAdmin.Access.AddPrivilege("giveweapon", 2)
     FAdmin.Commands.AddCommand("giveweapon", nil, "<Player>", "<weapon>")
-    FAdmin.Commands.AddCommand("giveholsterableweapon", nil, "<Player>", "<weapon>")
 
     FAdmin.ScoreBoard.Player:AddActionButton("Give weapon(s)", "fadmin/icons/weapon", Color(255, 130, 0, 255),
 

--- a/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/sv_init.lua
@@ -16,7 +16,8 @@ local function GiveWeapon(ply, cmd, args)
 
     for _, target in pairs(targets) do
         if IsValid(target) then
-            target:Give(weapon)
+            local wep = target:Give(weapon)
+            wep.VINVOneTimeUse = true
         end
     end
     FAdmin.Messages.ActionMessage(ply, targets, "You gave %s a " .. weapon, "%s gave you a " .. weapon, "Gave %s a " .. weapon)

--- a/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/sv_init.lua
@@ -17,10 +17,39 @@ local function GiveWeapon(ply, cmd, args)
     for _, target in pairs(targets) do
         if IsValid(target) then
             local wep = target:Give(weapon)
-            wep.VINVOneTimeUse = true
+            if (IsValid(wep)) then
+                wep.VINVOneTimeUse = true
+            end
         end
     end
     FAdmin.Messages.ActionMessage(ply, targets, "You gave %s a " .. weapon, "%s gave you a " .. weapon, "Gave %s a " .. weapon)
+    FAdmin.Messages.FireNotification("giveweapon", ply, targets, {weapon})
+
+    return true, targets, weapon
+end
+
+local function GiveHolsterableWeapon(ply, cmd, args)
+    if not FAdmin.Access.PlayerHasPrivilege(ply, "giveweapon") then FAdmin.Messages.SendMessage(ply, 5, "No access!") return false end
+    if not args[2] then return false end
+
+    local targets = FAdmin.FindPlayer(args[1])
+    if not targets or #targets == 1 and not IsValid(targets[1]) then
+        FAdmin.Messages.SendMessage(ply, 1, "Player not found")
+        return false
+    end
+
+    local weapon = weapons.GetStored(args[2])
+    if table.HasValue(FAdmin.HL2Guns, args[2]) then weapon = args[2]
+    elseif weapon and weapon.ClassName then weapon = weapon.ClassName end
+
+    if not weapon then return false end
+
+    for _, target in pairs(targets) do
+        if IsValid(target) then
+            target:Give(weapon)
+        end
+    end
+    FAdmin.Messages.ActionMessage(ply, targets, "You gave %s a HOLSTERABLE " .. weapon, "%s gave you a HOLSTERABLE " .. weapon, "Gave %s a HOLSTERABLE " .. weapon)
     FAdmin.Messages.FireNotification("giveweapon", ply, targets, {weapon})
 
     return true, targets, weapon
@@ -52,6 +81,7 @@ end
 
 FAdmin.StartHooks["GiveWeapons"] = function()
     FAdmin.Commands.AddCommand("giveweapon", GiveWeapon)
+    FAdmin.Commands.AddCommand("giveholsterableweapon", GiveHolsterableWeapon)
     FAdmin.Commands.AddCommand("giveammo", GiveAmmo)
 
     FAdmin.Access.AddPrivilege("giveweapon", 3)

--- a/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/sv_init.lua
@@ -28,33 +28,6 @@ local function GiveWeapon(ply, cmd, args)
     return true, targets, weapon
 end
 
-local function GiveHolsterableWeapon(ply, cmd, args)
-    if not FAdmin.Access.PlayerHasPrivilege(ply, "giveweapon") then FAdmin.Messages.SendMessage(ply, 5, "No access!") return false end
-    if not args[2] then return false end
-
-    local targets = FAdmin.FindPlayer(args[1])
-    if not targets or #targets == 1 and not IsValid(targets[1]) then
-        FAdmin.Messages.SendMessage(ply, 1, "Player not found")
-        return false
-    end
-
-    local weapon = weapons.GetStored(args[2])
-    if table.HasValue(FAdmin.HL2Guns, args[2]) then weapon = args[2]
-    elseif weapon and weapon.ClassName then weapon = weapon.ClassName end
-
-    if not weapon then return false end
-
-    for _, target in pairs(targets) do
-        if IsValid(target) then
-            target:Give(weapon)
-        end
-    end
-    FAdmin.Messages.ActionMessage(ply, targets, "You gave %s a HOLSTERABLE " .. weapon, "%s gave you a HOLSTERABLE " .. weapon, "Gave %s a HOLSTERABLE " .. weapon)
-    FAdmin.Messages.FireNotification("giveweapon", ply, targets, {weapon})
-
-    return true, targets, weapon
-end
-
 local function GiveAmmo(ply, cmd, args)
     if not FAdmin.Access.PlayerHasPrivilege(ply, "giveweapon") then FAdmin.Messages.SendMessage(ply, 5, "No access!") return false end
     if not args[2] or not FAdmin.AmmoTypes[args[2]] then return false end
@@ -81,7 +54,6 @@ end
 
 FAdmin.StartHooks["GiveWeapons"] = function()
     FAdmin.Commands.AddCommand("giveweapon", GiveWeapon)
-    FAdmin.Commands.AddCommand("giveholsterableweapon", GiveHolsterableWeapon)
     FAdmin.Commands.AddCommand("giveammo", GiveAmmo)
 
     FAdmin.Access.AddPrivilege("giveweapon", 3)


### PR DESCRIPTION
## PR Type
Exploit Fix

## Details
- Don't allow people to holster given weapons via `/giveweapon`
- Add new command, `/giveholsterableweapon`, that lets people holster them.